### PR TITLE
Mint support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,14 @@ license = "Apache-2.0 OR MIT"
 name = "bbox"
 path = "src/lib.rs"
 
+[features]
+mint = ["nalgebra/mint"]
+
 [dependencies]
-nalgebra = { version = "0.22", features = ["alga"] }
+nalgebra = { version = "0.24", features = ["alga"] }
 alga = "0.9"
 num-traits = "0.2"
-approx = "0.3"
+approx = "0.4"
 
 [badges]
 travis-ci = { repository = "hmeyer/bbox", branch = "master" }

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ let bbox = bbox::BoundingBox::<f64>::new(na::Point3::new(0., 0., 0.),
 let distance = bbox.distance(na::Point3::new(1., 1., 1.));
 ```
 
+## Cargo Features
+
+* `mint` - Enable interoperation with other math libraries through the
+  [`mint`](https://crates.io/crates/mint) interface.
+
 #### License
 
 <sup>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,10 @@
 //!                                          &na::Point3::new(1., 2., 3.));
 //! let distance = bbox.distance(&na::Point3::new(1., 1., 1.));
 //! ```
+//! ## Cargo Features
+//!
+//! * `mint` - Enable interoperation with other math libraries through the
+//!   [`mint`](https://crates.io/crates/mint) interface.
 #![warn(missing_docs)]
 use nalgebra as na;
 #[cfg(test)]


### PR DESCRIPTION
See subject. Very low hanging fruit. Allows users to easily use `bbox` with other math libs than `nalgebra`.

Also bumped the versions of `nalgebra` & `approx` to latest.