### PR TITLE
Upgrade dependencies and switch from alga to simba

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bbox"
-version = "0.11.2"
+version = "0.12.0"
 authors = ["Henning Meyer <tutmann@gmail.com>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ path = "src/lib.rs"
 mint = ["nalgebra/mint"]
 
 [dependencies]
-nalgebra = { version = "0.24", features = ["alga"] }
-alga = "0.9"
-num-traits = "0.2"
-approx = "0.4"
+approx = "0.5.0"
+nalgebra = "0.27.1"
+num-traits = "0.2.14"
+simba = "0.5.1"
 
 [badges]
 travis-ci = { repository = "hmeyer/bbox", branch = "master" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ fn point_max<S: 'static + Float + Debug>(p: &[na::Point3<S>]) -> na::Point3<S> {
     )
 }
 
-impl<S: Float + Debug + na::RealField + alga::general::RealField> BoundingBox<S> {
+impl<S: Float + Debug + na::RealField + simba::scalar::RealField> BoundingBox<S> {
     /// Returns an infinte sized box.
     pub fn infinity() -> BoundingBox<S> {
         BoundingBox {


### PR DESCRIPTION
The `alga` crate is deprecated and has been replaced by `simba`.  This PR also allows the introduction of a much newer `nalgebra` version which is pretty significant