### PR TITLE
Improve API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,15 @@ fn point_max<S: 'static + Float + Debug>(p: &[na::Point3<S>]) -> na::Point3<S> {
     )
 }
 
+impl<S: Float + na::RealField, T: AsRef<[na::Point3<S>]>> From<T> for BoundingBox<S> {
+    fn from(points: T) -> BoundingBox<S> {
+        BoundingBox {
+            min: point_min(points.as_ref()),
+            max: point_max(points.as_ref()),
+        }
+    }
+}
+
 impl<S: Float + Debug + na::RealField + simba::scalar::RealField> BoundingBox<S> {
     /// Returns an infinte sized box.
     pub fn infinity() -> BoundingBox<S> {
@@ -245,6 +254,23 @@ mod test {
         assert!(bbox.contains(&na::Point3::new(1., 1., 1.)));
         assert!(!bbox.contains(&na::Point3::new(2., 2., 2.)));
         assert!(!bbox.contains(&na::Point3::new(-1., -1., -1.)));
+    }
+
+    #[test]
+    fn box_from_points() {
+        let points = [
+            na::Point3::new(0., 0., 0.),
+            na::Point3::new(1., 1., 0.),
+            na::Point3::new(0., -2., 2.),
+        ];
+        for bbox in [
+            BoundingBox::from(points),            // from array
+            BoundingBox::from(&points[..]),       // from slice
+            BoundingBox::from(Vec::from(points)), // from vector
+        ] {
+            assert_relative_eq!(bbox.min, na::Point3::new(0., -2., 0.));
+            assert_relative_eq!(bbox.max, na::Point3::new(1., 1., 2.));
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,14 @@ impl<S: Float + Debug + na::RealField + simba::scalar::RealField> BoundingBox<S>
             && self.max.y.is_finite()
             && self.max.z.is_finite()
     }
+    /// Returns the center point of the Bounding Box.
+    pub fn center(&self) -> na::Point3<S> {
+        na::Point3::<S>::new(
+            (self.min.x + self.max.x) / S::from(2.0).unwrap(),
+            (self.min.y + self.max.y) / S::from(2.0).unwrap(),
+            (self.min.z + self.max.z) / S::from(2.0).unwrap(),
+        )
+    }
     /// Create a CSG Union of two Bounding Boxes.
     pub fn union(&self, other: &BoundingBox<S>) -> BoundingBox<S> {
         BoundingBox {
@@ -335,6 +343,13 @@ mod test {
             &na::Point3::new(f64::INFINITY, 1., 1.),
         );
         assert!(!bbox.is_finite());
+    }
+
+    #[test]
+    fn center() {
+        let bbox =
+            BoundingBox::<f64>::new(&na::Point3::new(0., 0., 0.), &na::Point3::new(1., 1., 1.));
+        assert_relative_eq!(bbox.center(), na::Point3::new(0.5, 0.5, 0.5));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,13 +204,14 @@ impl<S: Float + Debug + na::RealField + simba::scalar::RealField> BoundingBox<S>
         self
     }
     /// Add a Point to a Bounding Box, e.g. expand the Bounding Box to contain that point.
-    pub fn insert(&mut self, o: &na::Point3<S>) {
+    pub fn insert(&mut self, o: &na::Point3<S>) -> &mut Self {
         self.min.x = Float::min(self.min.x, o.x);
         self.min.y = Float::min(self.min.y, o.y);
         self.min.z = Float::min(self.min.z, o.z);
         self.max.x = Float::max(self.max.x, o.x);
         self.max.y = Float::max(self.max.y, o.y);
         self.max.z = Float::max(self.max.z, o.z);
+        self
     }
     /// Return the size of the Box.
     pub fn dim(&self) -> na::Vector3<S> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,22 @@
 //! distance a Point has to the Box.
 //! # Examples
 //!
+//! Insert points into a Bounding Box:
+//!
+//! ```rust
+//! use nalgebra as na;
+//! let mut bbox = bbox::BoundingBox::<f64>::neg_infinity();
+//! bbox.insert(&na::Point3::new(0., 0., 0.));
+//! bbox.insert(&na::Point3::new(1., 2., 3.));
+//!
+//! // or insert multiple points at once
+//!
+//! let bbox = bbox::BoundingBox::<f64>::from([na::Point3::new(0., 0., 0.),
+//!                                            na::Point3::new(1., 2., 3.)]);
+//! ```
 //! Intersect two Bounding Boxes:
 //!
-//! ```rust,no_run
+//! ```rust
 //! use nalgebra as na;
 //! let bbox1 = bbox::BoundingBox::<f64>::new(&na::Point3::new(0., 0., 0.),
 //!                                           &na::Point3::new(1., 2., 3.));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,22 +165,12 @@ impl<S: Float + Debug + na::RealField + simba::scalar::RealField> BoundingBox<S>
     }
     /// Transform a Bounding Box - resulting in a enclosing axis aligned Bounding Box.
     pub fn transform(&self, mat: &na::Matrix4<S>) -> BoundingBox<S> {
-        let a = &self.min;
-        let b = &self.max;
-        let corners = [
-            mat.transform_point(&na::Point3::<S>::new(a.x, a.y, a.z)),
-            mat.transform_point(&na::Point3::<S>::new(a.x, a.y, b.z)),
-            mat.transform_point(&na::Point3::<S>::new(a.x, b.y, a.z)),
-            mat.transform_point(&na::Point3::<S>::new(a.x, b.y, b.z)),
-            mat.transform_point(&na::Point3::<S>::new(b.x, a.y, a.z)),
-            mat.transform_point(&na::Point3::<S>::new(b.x, a.y, b.z)),
-            mat.transform_point(&na::Point3::<S>::new(b.x, b.y, a.z)),
-            mat.transform_point(&na::Point3::<S>::new(b.x, b.y, b.z)),
-        ];
-        BoundingBox {
-            min: point_min(&corners),
-            max: point_max(&corners),
-        }
+        let corners = self.get_corners();
+        let transformed: Vec<_> = corners
+            .into_iter()
+            .map(|c| mat.transform_point(&c))
+            .collect();
+        BoundingBox::from(&transformed)
     }
     /// Dilate a Bounding Box by some amount in all directions.
     pub fn dilate(&mut self, d: S) -> &mut Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,19 @@ impl<S: Float + Debug + na::RealField + simba::scalar::RealField> BoundingBox<S>
             max: point_min(&[self.max, other.max]),
         }
     }
+    /// Get the corners of the Bounding Box
+    pub fn get_corners(&self) -> [na::Point3<S>; 8] {
+        [
+            na::Point3::<S>::new(self.min.x, self.min.y, self.min.z),
+            na::Point3::<S>::new(self.min.x, self.min.y, self.max.z),
+            na::Point3::<S>::new(self.min.x, self.max.y, self.min.z),
+            na::Point3::<S>::new(self.min.x, self.max.y, self.max.z),
+            na::Point3::<S>::new(self.max.x, self.min.y, self.min.z),
+            na::Point3::<S>::new(self.max.x, self.min.y, self.max.z),
+            na::Point3::<S>::new(self.max.x, self.max.y, self.min.z),
+            na::Point3::<S>::new(self.max.x, self.max.y, self.max.z),
+        ]
+    }
     /// Transform a Bounding Box - resulting in a enclosing axis aligned Bounding Box.
     pub fn transform(&self, mat: &na::Matrix4<S>) -> BoundingBox<S> {
         let a = &self.min;
@@ -283,6 +296,21 @@ mod test {
             assert_relative_eq!(bbox.min, na::Point3::new(0., -2., 0.));
             assert_relative_eq!(bbox.max, na::Point3::new(1., 1., 2.));
         }
+    }
+
+    #[test]
+    fn get_corners() {
+        let bbox =
+            BoundingBox::<f64>::new(&na::Point3::new(1., 2., 3.), &na::Point3::new(4., 5., 6.));
+        let corners = bbox.get_corners();
+        assert!(corners.contains(&na::Point3::new(1., 2., 3.)));
+        assert!(corners.contains(&na::Point3::new(1., 2., 6.)));
+        assert!(corners.contains(&na::Point3::new(1., 5., 3.)));
+        assert!(corners.contains(&na::Point3::new(1., 5., 6.)));
+        assert!(corners.contains(&na::Point3::new(4., 2., 3.)));
+        assert!(corners.contains(&na::Point3::new(4., 2., 6.)));
+        assert!(corners.contains(&na::Point3::new(4., 5., 3.)));
+        assert!(corners.contains(&na::Point3::new(4., 5., 6.)));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,15 @@ impl<S: Float + Debug + na::RealField + simba::scalar::RealField> BoundingBox<S>
     pub fn is_empty(&self) -> bool {
         self.min > self.max
     }
+    /// Returns true if the Bounding Box has finite size.
+    pub fn is_finite(&self) -> bool {
+        self.min.x.is_finite()
+            && self.min.y.is_finite()
+            && self.min.z.is_finite()
+            && self.max.x.is_finite()
+            && self.max.y.is_finite()
+            && self.max.z.is_finite()
+    }
     /// Create a CSG Union of two Bounding Boxes.
     pub fn union(&self, other: &BoundingBox<S>) -> BoundingBox<S> {
         BoundingBox {
@@ -313,6 +322,19 @@ mod test {
         assert!(bbox.is_empty());
         let bbox = BoundingBox::<f64>::from([na::Point3::new(0., 0., 0.)]);
         assert!(!bbox.is_empty());
+    }
+
+    #[test]
+    fn is_finite() {
+        let bbox = BoundingBox::<f64>::neg_infinity();
+        assert!(!bbox.is_finite());
+        let bbox = BoundingBox::<f64>::from([na::Point3::new(0., 0., 0.)]);
+        assert!(bbox.is_finite());
+        let bbox = BoundingBox::<f64>::new(
+            &na::Point3::new(0., 0., 0.),
+            &na::Point3::new(f64::INFINITY, 1., 1.),
+        );
+        assert!(!bbox.is_finite());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,6 +136,10 @@ impl<S: Float + Debug + na::RealField + simba::scalar::RealField> BoundingBox<S>
             ),
         }
     }
+    /// Returns true if the Bounding Box is empty.
+    pub fn is_empty(&self) -> bool {
+        self.min > self.max
+    }
     /// Create a CSG Union of two Bounding Boxes.
     pub fn union(&self, other: &BoundingBox<S>) -> BoundingBox<S> {
         BoundingBox {
@@ -301,6 +305,14 @@ mod test {
         assert!(corners.contains(&na::Point3::new(4., 2., 6.)));
         assert!(corners.contains(&na::Point3::new(4., 5., 3.)));
         assert!(corners.contains(&na::Point3::new(4., 5., 6.)));
+    }
+
+    #[test]
+    fn is_empty() {
+        let bbox = BoundingBox::<f64>::neg_infinity();
+        assert!(bbox.is_empty());
+        let bbox = BoundingBox::<f64>::from([na::Point3::new(0., 0., 0.)]);
+        assert!(!bbox.is_empty());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -167,14 +167,13 @@ impl<S: Float + Debug + na::RealField + simba::scalar::RealField> BoundingBox<S>
         self
     }
     /// Add a Point to a Bounding Box, e.g. expand the Bounding Box to contain that point.
-    pub fn insert(&mut self, o: &na::Point3<S>) -> &mut Self {
+    pub fn insert(&mut self, o: &na::Point3<S>) {
         self.min.x = Float::min(self.min.x, o.x);
         self.min.y = Float::min(self.min.y, o.y);
         self.min.z = Float::min(self.min.z, o.z);
         self.max.x = Float::max(self.max.x, o.x);
         self.max.y = Float::max(self.max.y, o.y);
         self.max.z = Float::max(self.max.z, o.z);
-        self
     }
     /// Return the size of the Box.
     pub fn dim(&self) -> na::Vector3<S> {


### PR DESCRIPTION
As I mentioned in the email, I have made some API changes. I kept the new function unchanged because I realized that there is no reason to prefer a neg_infinity box over infinity box.

Changes:
- Implemented a From trait for easier creation of bbox from a list of points.
- Removed returning self in insert method. It is now only mutating.
- Added get_corners method. It is also used to simplify the implementation of the transform method.
- Added is_empty, is_finite and center methods.