### PR TITLE
Generalize dimensions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.14.1"
 authors = ["Henning Meyer <tutmann@gmail.com>"]
 edition = "2021"
 
-description = "Managing axis aligned 3d Bounding Boxes."
+description = "Managing axis aligned Bounding Boxes."
 repository = "https://github.com/hmeyer/bbox"
 readme = "README.md"
-keywords = ["boundingbox", "3d", "csg", "union", "intersection"]
+keywords = ["boundingbox", "csg", "union", "intersection"]
 license = "MIT"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -6,49 +6,61 @@
 [![Downloads](https://img.shields.io/crates/d/bbox.svg)](#downloads)
 
 
-bbox is crate for managing axis aligned 3d Bounding Boxes.
+bbox is crate for managing axis aligned Bounding Boxes.
 Bounding Boxes can be created, dilated, transformed and joined with other Bounding Boxes using
 CSG operations.
 Finally you can test whether or not a Bounding Box contains some point and what approximate
 distance a Point has to the Box.
-
 # Examples
 
-Intersect two Bounding Boxes
+Insert points into a Bounding Box:
+
 ```rust
 use nalgebra as na;
-let bbox1 = bbox::BoundingBox::<f64>::new(na::Point3::new(0., 0., 0.),
-                                          na::Point3::new(1., 2., 3.));
-let bbox2 = bbox::BoundingBox::<f64>::new(na::Point3::new(-1., -2., -3.),
-                                          na::Point3::new(3., 2., 1.));
+let mut bbox = bbox::BoundingBox::neg_infinity();
+bbox.insert(&na::Point::from([0., 0., 0.]));
+bbox.insert(&na::Point::from([1., 2., 3.]));
+
+// or insert multiple points at once
+
+let bbox = bbox::BoundingBox::from([na::Point::from([0., 0., 0.]),
+                                    na::Point::from([1., 2., 3.])]);
+```
+Intersect two Bounding Boxes:
+
+```rust
+use nalgebra as na;
+let bbox1 = bbox::BoundingBox::new(&na::Point::from([0., 0., 0.]),
+                                   &na::Point::from([1., 2., 3.]));
+let bbox2 = bbox::BoundingBox::new(&na::Point::from([-1., -2., -3.]),
+                                   &na::Point::from([3., 2., 1.]));
 let intersection = bbox1.intersection(&bbox2);
 ```
-
 Rotate a Bounding Box:
+
 ```rust
 use nalgebra as na;
-let rotation = na::Rotation::from_euler_angles(10., 11., 12.).to_homogeneous();
-let bbox = bbox::BoundingBox::<f64>::new(na::Point3::new(0., 0., 0.),
-                                         na::Point3::new(1., 2., 3.));
-let rotated_box = bbox.transform(&rotation);
+let rotation = na::Rotation::from_euler_angles(10., 11., 12.);
+let bbox = bbox::BoundingBox::new(&na::Point::from([0., 0., 0.]),
+                                  &na::Point::from([1., 2., 3.]));
+let rotated_box = bbox.transform(&rotation.to_homogeneous());
 ```
 Is a point contained in the Box?
 
 ```rust
 use nalgebra as na;
-let bbox = bbox::BoundingBox::<f64>::new(na::Point3::new(0., 0., 0.),
-                                         na::Point3::new(1., 2., 3.));
-let result = bbox.contains(na::Point3::new(1., 1., 1.));
+let bbox = bbox::BoundingBox::new(&na::Point::from([0., 0., 0.]),
+                                  &na::Point::from([1., 2., 3.]));
+let result = bbox.contains(&na::Point::from([1., 1., 1.]));
 ```
 Calculate approximate distance of a point to the Box:
 
 ```rust
 use nalgebra as na;
-let bbox = bbox::BoundingBox::<f64>::new(na::Point3::new(0., 0., 0.),
-                                         na::Point3::new(1., 2., 3.));
-let distance = bbox.distance(na::Point3::new(1., 1., 1.));
+let bbox = bbox::BoundingBox::new(&na::Point::from([0., 0., 0.]),
+                                  &na::Point::from([1., 2., 3.]));
+let distance = bbox.distance(&na::Point::from([1., 1., 1.]));
 ```
-
 ## Cargo Features
 
 * `mint` - Enable interoperation with other math libraries through the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,8 @@ use nalgebra as na;
 use num_traits::Float;
 use std::fmt::Debug;
 
-fn point_best<S: 'static + Float + Debug, const D: usize>(
+/// Apply a binary operation to every coordinate of a and b
+fn apply_binary_op<S: 'static + Float + Debug, const D: usize>(
     a: &na::Point<S, D>,
     b: &na::Point<S, D>,
     op: fn(S, S) -> S,
@@ -83,7 +84,7 @@ fn points_best<S: 'static + Float + Debug, const D: usize>(
 ) -> na::Point<S, D> {
     points.iter().fold(
         na::Point::from([-op(S::infinity(), S::neg_infinity()); D]),
-        |best, current| point_best(&best, current, op),
+        |best, current| apply_binary_op(&best, current, op),
     )
 }
 
@@ -91,14 +92,14 @@ fn point_min<S: 'static + Float + Debug, const D: usize>(
     a: &na::Point<S, D>,
     b: &na::Point<S, D>,
 ) -> na::Point<S, D> {
-    point_best(a, b, S::min)
+    apply_binary_op(a, b, S::min)
 }
 
 fn point_max<S: 'static + Float + Debug, const D: usize>(
     a: &na::Point<S, D>,
     b: &na::Point<S, D>,
 ) -> na::Point<S, D> {
-    point_best(a, b, S::max)
+    apply_binary_op(a, b, S::max)
 }
 
 fn points_min<S: 'static + Float + Debug, const D: usize>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,8 +97,8 @@ fn point_max<S: 'static + Float + Debug, const D: usize>(p: &[na::Point<S, D>]) 
 }
 
 impl<S: Float + na::RealField, T: AsRef<[na::Point<S, 3>]>> From<T> for BoundingBox<S> {
-    fn from(points: T) -> BoundingBox<S> {
-        BoundingBox {
+    fn from(points: T) -> Self {
+        Self {
             min: point_min(points.as_ref()),
             max: point_max(points.as_ref()),
         }
@@ -107,22 +107,22 @@ impl<S: Float + na::RealField, T: AsRef<[na::Point<S, 3>]>> From<T> for Bounding
 
 impl<S: Float + Debug + na::RealField + simba::scalar::RealField> BoundingBox<S> {
     /// Returns an infinte sized box.
-    pub fn infinity() -> BoundingBox<S> {
-        BoundingBox {
+    pub fn infinity() -> Self {
+        Self {
             min: na::Point::from([S::neg_infinity(), S::neg_infinity(), S::neg_infinity()]),
             max: na::Point::from([S::infinity(), S::infinity(), S::infinity()]),
         }
     }
     /// Returns a negatively infinte sized box.
-    pub fn neg_infinity() -> BoundingBox<S> {
-        BoundingBox {
+    pub fn neg_infinity() -> Self {
+        Self {
             min: na::Point::from([S::infinity(), S::infinity(), S::infinity()]),
             max: na::Point::from([S::neg_infinity(), S::neg_infinity(), S::neg_infinity()]),
         }
     }
     /// Create a new Bounding Box by supplying two points.
-    pub fn new(a: &na::Point<S, 3>, b: &na::Point<S, 3>) -> BoundingBox<S> {
-        BoundingBox {
+    pub fn new(a: &na::Point<S, 3>, b: &na::Point<S, 3>) -> Self {
+        Self {
             min: na::Point::from([
                 Float::min(a.x, b.x),
                 Float::min(a.y, b.y),
@@ -157,15 +157,15 @@ impl<S: Float + Debug + na::RealField + simba::scalar::RealField> BoundingBox<S>
         ])
     }
     /// Create a CSG Union of two Bounding Boxes.
-    pub fn union(&self, other: &BoundingBox<S>) -> BoundingBox<S> {
-        BoundingBox {
+    pub fn union(&self, other: &Self) -> Self {
+        Self {
             min: point_min(&[self.min, other.min]),
             max: point_max(&[self.max, other.max]),
         }
     }
     /// Create a CSG Intersection of two Bounding Boxes.
-    pub fn intersection(&self, other: &BoundingBox<S>) -> BoundingBox<S> {
-        BoundingBox {
+    pub fn intersection(&self, other: &Self) -> Self {
+        Self {
             min: point_max(&[self.min, other.min]),
             max: point_min(&[self.max, other.max]),
         }
@@ -184,13 +184,13 @@ impl<S: Float + Debug + na::RealField + simba::scalar::RealField> BoundingBox<S>
         ]
     }
     /// Transform a Bounding Box - resulting in a enclosing axis aligned Bounding Box.
-    pub fn transform(&self, mat: &na::Matrix4<S>) -> BoundingBox<S> {
+    pub fn transform(&self, mat: &na::Matrix4<S>) -> Self {
         let corners = self.get_corners();
         let transformed: Vec<_> = corners
             .into_iter()
             .map(|c| mat.transform_point(&c))
             .collect();
-        BoundingBox::from(&transformed)
+        Self::from(&transformed)
     }
     /// Dilate a Bounding Box by some amount in all directions.
     pub fn dilate(&mut self, d: S) -> &mut Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,22 +9,22 @@
 //!
 //! ```rust
 //! use nalgebra as na;
-//! let mut bbox = bbox::BoundingBox::<f64>::neg_infinity();
+//! let mut bbox = bbox::BoundingBox::neg_infinity();
 //! bbox.insert(&na::Point::from([0., 0., 0.]));
 //! bbox.insert(&na::Point::from([1., 2., 3.]));
 //!
 //! // or insert multiple points at once
 //!
-//! let bbox = bbox::BoundingBox::<f64>::from([na::Point::from([0., 0., 0.]),
+//! let bbox = bbox::BoundingBox::from([na::Point::from([0., 0., 0.]),
 //!                                            na::Point::from([1., 2., 3.])]);
 //! ```
 //! Intersect two Bounding Boxes:
 //!
 //! ```rust
 //! use nalgebra as na;
-//! let bbox1 = bbox::BoundingBox::<f64>::new(&na::Point::from([0., 0., 0.]),
+//! let bbox1 = bbox::BoundingBox::new(&na::Point::from([0., 0., 0.]),
 //!                                           &na::Point::from([1., 2., 3.]));
-//! let bbox2 = bbox::BoundingBox::<f64>::new(&na::Point::from([-1., -2., -3.]),
+//! let bbox2 = bbox::BoundingBox::new(&na::Point::from([-1., -2., -3.]),
 //!                                           &na::Point::from([3., 2., 1.]));
 //! let intersection = bbox1.intersection(&bbox2);
 //! ```
@@ -33,7 +33,7 @@
 //! ```rust
 //! use nalgebra as na;
 //! let rotation = na::Rotation::from_euler_angles(10., 11., 12.);
-//! let bbox = bbox::BoundingBox::<f64>::new(&na::Point::from([0., 0., 0.]),
+//! let bbox = bbox::BoundingBox::new(&na::Point::from([0., 0., 0.]),
 //!                                          &na::Point::from([1., 2., 3.]));
 //! let rotated_box = bbox.transform(&rotation.to_homogeneous());
 //! ```
@@ -41,7 +41,7 @@
 //!
 //! ```rust
 //! use nalgebra as na;
-//! let bbox = bbox::BoundingBox::<f64>::new(&na::Point::from([0., 0., 0.]),
+//! let bbox = bbox::BoundingBox::new(&na::Point::from([0., 0., 0.]),
 //!                                          &na::Point::from([1., 2., 3.]));
 //! let result = bbox.contains(&na::Point::from([1., 1., 1.]));
 //! ```
@@ -49,7 +49,7 @@
 //!
 //! ```rust
 //! use nalgebra as na;
-//! let bbox = bbox::BoundingBox::<f64>::new(&na::Point::from([0., 0., 0.]),
+//! let bbox = bbox::BoundingBox::new(&na::Point::from([0., 0., 0.]),
 //!                                          &na::Point::from([1., 2., 3.]));
 //! let distance = bbox.distance(&na::Point::from([1., 1., 1.]));
 //! ```
@@ -283,7 +283,7 @@ mod test {
 
     #[test]
     fn box_contains_points_inside() {
-        let bbox = BoundingBox::<f64>::new(
+        let bbox = BoundingBox::new(
             &na::Point::from([0., 0., 0.]),
             &na::Point::from([1., 2., 3.]),
         );
@@ -314,7 +314,7 @@ mod test {
 
     #[test]
     fn get_corners() {
-        let bbox = BoundingBox::<f64>::new(
+        let bbox = BoundingBox::new(
             &na::Point::from([1., 2., 3.]),
             &na::Point::from([4., 5., 6.]),
         );
@@ -333,7 +333,7 @@ mod test {
     fn is_empty() {
         let bbox = BoundingBox::<f64>::neg_infinity();
         assert!(bbox.is_empty());
-        let bbox = BoundingBox::<f64>::from([na::Point::from([0., 0., 0.])]);
+        let bbox = BoundingBox::from([na::Point::from([0., 0., 0.])]);
         assert!(!bbox.is_empty());
     }
 
@@ -341,9 +341,9 @@ mod test {
     fn is_finite() {
         let bbox = BoundingBox::<f64>::neg_infinity();
         assert!(!bbox.is_finite());
-        let bbox = BoundingBox::<f64>::from([na::Point::from([0., 0., 0.])]);
+        let bbox = BoundingBox::from([na::Point::from([0., 0., 0.])]);
         assert!(bbox.is_finite());
-        let bbox = BoundingBox::<f64>::new(
+        let bbox = BoundingBox::new(
             &na::Point::from([0., 0., 0.]),
             &na::Point::from([f64::INFINITY, 1., 1.]),
         );
@@ -352,7 +352,7 @@ mod test {
 
     #[test]
     fn center() {
-        let bbox = BoundingBox::<f64>::new(
+        let bbox = BoundingBox::new(
             &na::Point::from([0., 0., 0.]),
             &na::Point::from([1., 1., 1.]),
         );
@@ -361,13 +361,13 @@ mod test {
 
     #[test]
     fn transform_with_translation() {
-        let bbox = BoundingBox::<f64>::new(
+        let bbox = BoundingBox::new(
             &na::Point::from([0., 0., 0.]),
             &na::Point::from([1., 1., 1.]),
         );
         assert_relative_eq!(
             bbox.transform(&na::Translation3::new(1., 2., 3.).to_homogeneous()),
-            BoundingBox::<f64>::new(
+            BoundingBox::new(
                 &na::Point::from([1., 2., 3.]),
                 &na::Point::from([2., 3., 4.]),
             )
@@ -376,7 +376,7 @@ mod test {
 
     #[test]
     fn transform_with_rotation() {
-        let bbox = BoundingBox::<f64>::new(
+        let bbox = BoundingBox::new(
             &na::Point::from([0., 0., 0.]),
             &na::Point::from([1., 1., 1.]),
         );
@@ -385,7 +385,7 @@ mod test {
                 &na::Rotation::from_euler_angles(::std::f64::consts::PI / 2., 0., 0.)
                     .to_homogeneous()
             ),
-            BoundingBox::<f64>::new(
+            BoundingBox::new(
                 &na::Point::from([0., -1., 0.]),
                 &na::Point::from([1., 0., 1.]),
             )
@@ -394,17 +394,17 @@ mod test {
 
     #[test]
     fn union_of_two_boxes() {
-        let bbox1 = BoundingBox::<f64>::new(
+        let bbox1 = BoundingBox::new(
             &na::Point::from([0., 0., 0.]),
             &na::Point::from([4., 8., 16.]),
         );
-        let bbox2 = BoundingBox::<f64>::new(
+        let bbox2 = BoundingBox::new(
             &na::Point::from([2., 2., 2.]),
             &na::Point::from([16., 4., 8.]),
         );
         assert_relative_eq!(
             bbox1.union(&bbox2),
-            BoundingBox::<f64>::new(
+            BoundingBox::new(
                 &na::Point::from([0., 0., 0.]),
                 &na::Point::from([16., 8., 16.]),
             )
@@ -413,17 +413,17 @@ mod test {
 
     #[test]
     fn intersection_of_two_boxes() {
-        let bbox1 = BoundingBox::<f64>::new(
+        let bbox1 = BoundingBox::new(
             &na::Point::from([0., 0., 0.]),
             &na::Point::from([4., 8., 16.]),
         );
-        let bbox2 = BoundingBox::<f64>::new(
+        let bbox2 = BoundingBox::new(
             &na::Point::from([2., 2., 2.]),
             &na::Point::from([16., 4., 8.]),
         );
         assert_relative_eq!(
             bbox1.intersection(&bbox2),
-            BoundingBox::<f64>::new(
+            BoundingBox::new(
                 &na::Point::from([2., 2., 2.]),
                 &na::Point::from([4., 4., 8.]),
             )
@@ -432,20 +432,20 @@ mod test {
 
     #[test]
     fn dilate() {
-        let mut bbox = BoundingBox::<f64>::new(
+        let mut bbox = BoundingBox::new(
             &na::Point::from([0., 0., 0.]),
             &na::Point::from([1., 1., 1.]),
         );
         assert_relative_eq!(
             bbox.dilate(0.1),
-            &mut BoundingBox::<f64>::new(
+            &mut BoundingBox::new(
                 &na::Point::from([-0.1, -0.1, -0.1]),
                 &na::Point::from([1.1, 1.1, 1.1]),
             )
         );
         assert_relative_eq!(
             bbox.dilate(-0.5),
-            &mut BoundingBox::<f64>::new(
+            &mut BoundingBox::new(
                 &na::Point::from([0.4, 0.4, 0.4]),
                 &na::Point::from([0.6, 0.6, 0.6]),
             )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,10 +78,10 @@ fn point_best<S: 'static + Float + Debug, const D: usize>(
 }
 
 fn points_best<S: 'static + Float + Debug, const D: usize>(
-    p: &[na::Point<S, D>],
+    points: &[na::Point<S, D>],
     op: fn(S, S) -> S,
 ) -> na::Point<S, D> {
-    p.iter().fold(
+    points.iter().fold(
         na::Point::from([-op(S::infinity(), S::neg_infinity()); D]),
         |best, current| point_best(&best, current, op),
     )
@@ -102,15 +102,15 @@ fn point_max<S: 'static + Float + Debug, const D: usize>(
 }
 
 fn points_min<S: 'static + Float + Debug, const D: usize>(
-    p: &[na::Point<S, D>],
+    points: &[na::Point<S, D>],
 ) -> na::Point<S, D> {
-    points_best(p, S::min)
+    points_best(points, S::min)
 }
 
 fn points_max<S: 'static + Float + Debug, const D: usize>(
-    p: &[na::Point<S, D>],
+    points: &[na::Point<S, D>],
 ) -> na::Point<S, D> {
-    points_best(p, S::max)
+    points_best(points, S::max)
 }
 
 /// 3D Bounding Box - defined by two diagonally opposing points.
@@ -232,23 +232,23 @@ impl<S: Float + Debug + na::RealField + simba::scalar::RealField> BoundingBox<S>
     }
     /// Returns the approximate distance of p to the box. The result is guarateed to be not less
     /// than the euclidean distance of p to the box.
-    pub fn distance(&self, p: &na::Point<S, 3>) -> S {
+    pub fn distance(&self, point: &na::Point<S, 3>) -> S {
         // If p is not inside (neg), then it is outside (pos) on only one side.
         // So so calculating the max of the diffs on both sides should result in the true value,
         // if positive.
-        let xval = Float::max(p.x - self.max.x, self.min.x - p.x);
-        let yval = Float::max(p.y - self.max.y, self.min.y - p.y);
-        let zval = Float::max(p.z - self.max.z, self.min.z - p.z);
+        let xval = Float::max(point.x - self.max.x, self.min.x - point.x);
+        let yval = Float::max(point.y - self.max.y, self.min.y - point.y);
+        let zval = Float::max(point.z - self.max.z, self.min.z - point.z);
         Float::max(xval, Float::max(yval, zval))
     }
     /// Return true if the Bounding Box contains p.
-    pub fn contains(&self, p: &na::Point<S, 3>) -> bool {
-        p.x >= self.min.x
-            && p.x <= self.max.x
-            && p.y >= self.min.y
-            && p.y <= self.max.y
-            && p.z >= self.min.z
-            && p.z <= self.max.z
+    pub fn contains(&self, point: &na::Point<S, 3>) -> bool {
+        point.x >= self.min.x
+            && point.x <= self.max.x
+            && point.y >= self.min.y
+            && point.y <= self.max.y
+            && point.z >= self.min.z
+            && point.z <= self.max.z
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,14 +78,13 @@ fn apply_binary_op<S: 'static + Float + Debug, const D: usize>(
     best
 }
 
-fn points_best<S: 'static + Float + Debug, const D: usize>(
-    points: &[na::Point<S, D>],
+/// Fold points with a binary operation applied to every coordinate
+fn fold_points<'a, S: 'static + Float + Debug, const D: usize>(
+    initial: na::Point<S, D>,
+    points: impl Iterator<Item = &'a na::Point<S, D>>,
     op: fn(S, S) -> S,
 ) -> na::Point<S, D> {
-    points.iter().fold(
-        na::Point::from([-op(S::infinity(), S::neg_infinity()); D]),
-        |best, current| apply_binary_op(&best, current, op),
-    )
+    points.fold(initial, |best, current| apply_binary_op(&best, current, op))
 }
 
 fn point_min<S: 'static + Float + Debug, const D: usize>(
@@ -105,13 +104,13 @@ fn point_max<S: 'static + Float + Debug, const D: usize>(
 fn points_min<S: 'static + Float + Debug, const D: usize>(
     points: &[na::Point<S, D>],
 ) -> na::Point<S, D> {
-    points_best(points, S::min)
+    fold_points([S::infinity(); D].into(), points.iter(), S::min)
 }
 
 fn points_max<S: 'static + Float + Debug, const D: usize>(
     points: &[na::Point<S, D>],
 ) -> na::Point<S, D> {
-    points_best(points, S::max)
+    fold_points([S::neg_infinity(); D].into(), points.iter(), S::max)
 }
 
 /// 3D Bounding Box - defined by two diagonally opposing points.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,14 +69,14 @@ use std::fmt::Debug;
 #[derive(Clone, Debug, PartialEq)]
 pub struct BoundingBox<S: 'static + Debug + Copy + PartialEq> {
     /// X-Y-Z-Minimum corner of the box.
-    pub min: na::Point3<S>,
+    pub min: na::Point<S, 3>,
     /// X-Y-Z-Maximum corner of the box.
-    pub max: na::Point3<S>,
+    pub max: na::Point<S, 3>,
 }
 
-fn point_min<S: 'static + Float + Debug>(p: &[na::Point3<S>]) -> na::Point3<S> {
+fn point_min<S: 'static + Float + Debug>(p: &[na::Point<S, 3>]) -> na::Point<S, 3> {
     p.iter().fold(
-        na::Point3::<S>::new(S::infinity(), S::infinity(), S::infinity()),
+        na::Point::from([S::infinity(), S::infinity(), S::infinity()]),
         |mut min, current| {
             min.x = min.x.min(current.x);
             min.y = min.y.min(current.y);
@@ -85,9 +85,9 @@ fn point_min<S: 'static + Float + Debug>(p: &[na::Point3<S>]) -> na::Point3<S> {
         },
     )
 }
-fn point_max<S: 'static + Float + Debug>(p: &[na::Point3<S>]) -> na::Point3<S> {
+fn point_max<S: 'static + Float + Debug>(p: &[na::Point<S, 3>]) -> na::Point<S, 3> {
     p.iter().fold(
-        na::Point3::<S>::new(S::neg_infinity(), S::neg_infinity(), S::neg_infinity()),
+        na::Point::from([S::neg_infinity(), S::neg_infinity(), S::neg_infinity()]),
         |mut max, current| {
             max.x = max.x.max(current.x);
             max.y = max.y.max(current.y);
@@ -97,7 +97,7 @@ fn point_max<S: 'static + Float + Debug>(p: &[na::Point3<S>]) -> na::Point3<S> {
     )
 }
 
-impl<S: Float + na::RealField, T: AsRef<[na::Point3<S>]>> From<T> for BoundingBox<S> {
+impl<S: Float + na::RealField, T: AsRef<[na::Point<S, 3>]>> From<T> for BoundingBox<S> {
     fn from(points: T) -> BoundingBox<S> {
         BoundingBox {
             min: point_min(points.as_ref()),
@@ -110,30 +110,30 @@ impl<S: Float + Debug + na::RealField + simba::scalar::RealField> BoundingBox<S>
     /// Returns an infinte sized box.
     pub fn infinity() -> BoundingBox<S> {
         BoundingBox {
-            min: na::Point3::<S>::new(S::neg_infinity(), S::neg_infinity(), S::neg_infinity()),
-            max: na::Point3::<S>::new(S::infinity(), S::infinity(), S::infinity()),
+            min: na::Point::from([S::neg_infinity(), S::neg_infinity(), S::neg_infinity()]),
+            max: na::Point::from([S::infinity(), S::infinity(), S::infinity()]),
         }
     }
     /// Returns a negatively infinte sized box.
     pub fn neg_infinity() -> BoundingBox<S> {
         BoundingBox {
-            min: na::Point3::<S>::new(S::infinity(), S::infinity(), S::infinity()),
-            max: na::Point3::<S>::new(S::neg_infinity(), S::neg_infinity(), S::neg_infinity()),
+            min: na::Point::from([S::infinity(), S::infinity(), S::infinity()]),
+            max: na::Point::from([S::neg_infinity(), S::neg_infinity(), S::neg_infinity()]),
         }
     }
     /// Create a new Bounding Box by supplying two points.
-    pub fn new(a: &na::Point3<S>, b: &na::Point3<S>) -> BoundingBox<S> {
+    pub fn new(a: &na::Point<S, 3>, b: &na::Point<S, 3>) -> BoundingBox<S> {
         BoundingBox {
-            min: na::Point3::<S>::new(
+            min: na::Point::from([
                 Float::min(a.x, b.x),
                 Float::min(a.y, b.y),
                 Float::min(a.z, b.z),
-            ),
-            max: na::Point3::<S>::new(
+            ]),
+            max: na::Point::from([
                 Float::max(a.x, b.x),
                 Float::max(a.y, b.y),
                 Float::max(a.z, b.z),
-            ),
+            ]),
         }
     }
     /// Returns true if the Bounding Box is empty.
@@ -150,12 +150,12 @@ impl<S: Float + Debug + na::RealField + simba::scalar::RealField> BoundingBox<S>
             && self.max.z.is_finite()
     }
     /// Returns the center point of the Bounding Box.
-    pub fn center(&self) -> na::Point3<S> {
-        na::Point3::<S>::new(
+    pub fn center(&self) -> na::Point<S, 3> {
+        na::Point::from([
             (self.min.x + self.max.x) / S::from(2.0).unwrap(),
             (self.min.y + self.max.y) / S::from(2.0).unwrap(),
             (self.min.z + self.max.z) / S::from(2.0).unwrap(),
-        )
+        ])
     }
     /// Create a CSG Union of two Bounding Boxes.
     pub fn union(&self, other: &BoundingBox<S>) -> BoundingBox<S> {
@@ -172,16 +172,16 @@ impl<S: Float + Debug + na::RealField + simba::scalar::RealField> BoundingBox<S>
         }
     }
     /// Get the corners of the Bounding Box
-    pub fn get_corners(&self) -> [na::Point3<S>; 8] {
+    pub fn get_corners(&self) -> [na::Point<S, 3>; 8] {
         [
-            na::Point3::<S>::new(self.min.x, self.min.y, self.min.z),
-            na::Point3::<S>::new(self.min.x, self.min.y, self.max.z),
-            na::Point3::<S>::new(self.min.x, self.max.y, self.min.z),
-            na::Point3::<S>::new(self.min.x, self.max.y, self.max.z),
-            na::Point3::<S>::new(self.max.x, self.min.y, self.min.z),
-            na::Point3::<S>::new(self.max.x, self.min.y, self.max.z),
-            na::Point3::<S>::new(self.max.x, self.max.y, self.min.z),
-            na::Point3::<S>::new(self.max.x, self.max.y, self.max.z),
+            na::Point::from([self.min.x, self.min.y, self.min.z]),
+            na::Point::from([self.min.x, self.min.y, self.max.z]),
+            na::Point::from([self.min.x, self.max.y, self.min.z]),
+            na::Point::from([self.min.x, self.max.y, self.max.z]),
+            na::Point::from([self.max.x, self.min.y, self.min.z]),
+            na::Point::from([self.max.x, self.min.y, self.max.z]),
+            na::Point::from([self.max.x, self.max.y, self.min.z]),
+            na::Point::from([self.max.x, self.max.y, self.max.z]),
         ]
     }
     /// Transform a Bounding Box - resulting in a enclosing axis aligned Bounding Box.
@@ -204,7 +204,7 @@ impl<S: Float + Debug + na::RealField + simba::scalar::RealField> BoundingBox<S>
         self
     }
     /// Add a Point to a Bounding Box, e.g. expand the Bounding Box to contain that point.
-    pub fn insert(&mut self, o: &na::Point3<S>) -> &mut Self {
+    pub fn insert(&mut self, o: &na::Point<S, 3>) -> &mut Self {
         self.min.x = Float::min(self.min.x, o.x);
         self.min.y = Float::min(self.min.y, o.y);
         self.min.z = Float::min(self.min.z, o.z);
@@ -219,7 +219,7 @@ impl<S: Float + Debug + na::RealField + simba::scalar::RealField> BoundingBox<S>
     }
     /// Returns the approximate distance of p to the box. The result is guarateed to be not less
     /// than the euclidean distance of p to the box.
-    pub fn distance(&self, p: &na::Point3<S>) -> S {
+    pub fn distance(&self, p: &na::Point<S, 3>) -> S {
         // If p is not inside (neg), then it is outside (pos) on only one side.
         // So so calculating the max of the diffs on both sides should result in the true value,
         // if positive.
@@ -229,7 +229,7 @@ impl<S: Float + Debug + na::RealField + simba::scalar::RealField> BoundingBox<S>
         Float::max(xval, Float::max(yval, zval))
     }
     /// Return true if the Bounding Box contains p.
-    pub fn contains(&self, p: &na::Point3<S>) -> bool {
+    pub fn contains(&self, p: &na::Point<S, 3>) -> bool {
         p.x >= self.min.x
             && p.x <= self.max.x
             && p.y >= self.min.y
@@ -251,8 +251,8 @@ where
     }
 
     fn abs_diff_eq(&self, other: &Self, epsilon: Self::Epsilon) -> bool {
-        na::Point3::abs_diff_eq(&self.min, &other.min, epsilon)
-            && na::Point3::abs_diff_eq(&self.max, &other.max, epsilon)
+        na::Point::abs_diff_eq(&self.min, &other.min, epsilon)
+            && na::Point::abs_diff_eq(&self.max, &other.max, epsilon)
     }
 }
 
@@ -271,8 +271,8 @@ where
         epsilon: <T as AbsDiffEq>::Epsilon,
         max_relative: <T as AbsDiffEq>::Epsilon,
     ) -> bool {
-        na::Point3::relative_eq(&self.min, &other.min, epsilon, max_relative)
-            && na::Point3::relative_eq(&self.max, &other.max, epsilon, max_relative)
+        na::Point::relative_eq(&self.min, &other.min, epsilon, max_relative)
+            && na::Point::relative_eq(&self.max, &other.max, epsilon, max_relative)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,7 +191,6 @@ impl<S: Float + Debug + na::RealField + simba::scalar::RealField, const D: usize
     /// Warning: bounding box of dimension D has 2^D corners
     pub fn get_corners(&self) -> Vec<na::Point<S, 3>> {
         (0..2usize.pow(3))
-            .into_iter()
             .map(|i| {
                 na::Point::from(std::array::from_fn(|d| match (i >> d) & 1 {
                     0 => self.min[d],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,16 +101,16 @@ fn point_max<S: 'static + Float + Debug, const D: usize>(
     apply_binary_op(a, b, S::max)
 }
 
-fn points_min<S: 'static + Float + Debug, const D: usize>(
-    points: &[na::Point<S, D>],
+fn points_min<'a, S: 'static + Float + Debug, const D: usize>(
+    points: impl Iterator<Item = &'a na::Point<S, D>>,
 ) -> na::Point<S, D> {
-    fold_points([S::infinity(); D].into(), points.iter(), S::min)
+    fold_points([S::infinity(); D].into(), points, S::min)
 }
 
-fn points_max<S: 'static + Float + Debug, const D: usize>(
-    points: &[na::Point<S, D>],
+fn points_max<'a, S: 'static + Float + Debug, const D: usize>(
+    points: impl Iterator<Item = &'a na::Point<S, D>>,
 ) -> na::Point<S, D> {
-    fold_points([S::neg_infinity(); D].into(), points.iter(), S::max)
+    fold_points([S::neg_infinity(); D].into(), points, S::max)
 }
 
 /// 3D Bounding Box - defined by two diagonally opposing points.
@@ -127,8 +127,8 @@ impl<S: Float + na::RealField, T: AsRef<[na::Point<S, D>]>, const D: usize> From
 {
     fn from(points: T) -> Self {
         Self {
-            min: points_min(points.as_ref()),
-            max: points_max(points.as_ref()),
+            min: points_min(points.as_ref().iter()),
+            max: points_max(points.as_ref().iter()),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! bbox is crate for managing axis aligned 3d Bounding Boxes.
+//! bbox is crate for managing axis aligned Bounding Boxes.
 //! Bounding Boxes can be created, dilated, transformed and joined with other Bounding Boxes using
 //! CSG operations.
 //! Finally you can test whether or not a Bounding Box contains some point and what approximate
@@ -16,16 +16,16 @@
 //! // or insert multiple points at once
 //!
 //! let bbox = bbox::BoundingBox::from([na::Point::from([0., 0., 0.]),
-//!                                            na::Point::from([1., 2., 3.])]);
+//!                                     na::Point::from([1., 2., 3.])]);
 //! ```
 //! Intersect two Bounding Boxes:
 //!
 //! ```rust
 //! use nalgebra as na;
 //! let bbox1 = bbox::BoundingBox::new(&na::Point::from([0., 0., 0.]),
-//!                                           &na::Point::from([1., 2., 3.]));
+//!                                    &na::Point::from([1., 2., 3.]));
 //! let bbox2 = bbox::BoundingBox::new(&na::Point::from([-1., -2., -3.]),
-//!                                           &na::Point::from([3., 2., 1.]));
+//!                                    &na::Point::from([3., 2., 1.]));
 //! let intersection = bbox1.intersection(&bbox2);
 //! ```
 //! Rotate a Bounding Box:
@@ -34,7 +34,7 @@
 //! use nalgebra as na;
 //! let rotation = na::Rotation::from_euler_angles(10., 11., 12.);
 //! let bbox = bbox::BoundingBox::new(&na::Point::from([0., 0., 0.]),
-//!                                          &na::Point::from([1., 2., 3.]));
+//!                                   &na::Point::from([1., 2., 3.]));
 //! let rotated_box = bbox.transform(&rotation.to_homogeneous());
 //! ```
 //! Is a point contained in the Box?
@@ -42,7 +42,7 @@
 //! ```rust
 //! use nalgebra as na;
 //! let bbox = bbox::BoundingBox::new(&na::Point::from([0., 0., 0.]),
-//!                                          &na::Point::from([1., 2., 3.]));
+//!                                   &na::Point::from([1., 2., 3.]));
 //! let result = bbox.contains(&na::Point::from([1., 1., 1.]));
 //! ```
 //! Calculate approximate distance of a point to the Box:
@@ -50,7 +50,7 @@
 //! ```rust
 //! use nalgebra as na;
 //! let bbox = bbox::BoundingBox::new(&na::Point::from([0., 0., 0.]),
-//!                                          &na::Point::from([1., 2., 3.]));
+//!                                   &na::Point::from([1., 2., 3.]));
 //! let distance = bbox.distance(&na::Point::from([1., 1., 1.]));
 //! ```
 //! ## Cargo Features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,22 +10,22 @@
 //! ```rust
 //! use nalgebra as na;
 //! let mut bbox = bbox::BoundingBox::<f64>::neg_infinity();
-//! bbox.insert(&na::Point3::new(0., 0., 0.));
-//! bbox.insert(&na::Point3::new(1., 2., 3.));
+//! bbox.insert(&na::Point::from([0., 0., 0.]));
+//! bbox.insert(&na::Point::from([1., 2., 3.]));
 //!
 //! // or insert multiple points at once
 //!
-//! let bbox = bbox::BoundingBox::<f64>::from([na::Point3::new(0., 0., 0.),
-//!                                            na::Point3::new(1., 2., 3.)]);
+//! let bbox = bbox::BoundingBox::<f64>::from([na::Point::from([0., 0., 0.]),
+//!                                            na::Point::from([1., 2., 3.])]);
 //! ```
 //! Intersect two Bounding Boxes:
 //!
 //! ```rust
 //! use nalgebra as na;
-//! let bbox1 = bbox::BoundingBox::<f64>::new(&na::Point3::new(0., 0., 0.),
-//!                                           &na::Point3::new(1., 2., 3.));
-//! let bbox2 = bbox::BoundingBox::<f64>::new(&na::Point3::new(-1., -2., -3.),
-//!                                           &na::Point3::new(3., 2., 1.));
+//! let bbox1 = bbox::BoundingBox::<f64>::new(&na::Point::from([0., 0., 0.]),
+//!                                           &na::Point::from([1., 2., 3.]));
+//! let bbox2 = bbox::BoundingBox::<f64>::new(&na::Point::from([-1., -2., -3.]),
+//!                                           &na::Point::from([3., 2., 1.]));
 //! let intersection = bbox1.intersection(&bbox2);
 //! ```
 //! Rotate a Bounding Box:
@@ -33,25 +33,25 @@
 //! ```rust
 //! use nalgebra as na;
 //! let rotation = na::Rotation::from_euler_angles(10., 11., 12.);
-//! let bbox = bbox::BoundingBox::<f64>::new(&na::Point3::new(0., 0., 0.),
-//!                                          &na::Point3::new(1., 2., 3.));
+//! let bbox = bbox::BoundingBox::<f64>::new(&na::Point::from([0., 0., 0.]),
+//!                                          &na::Point::from([1., 2., 3.]));
 //! let rotated_box = bbox.transform(&rotation.to_homogeneous());
 //! ```
 //! Is a point contained in the Box?
 //!
 //! ```rust
 //! use nalgebra as na;
-//! let bbox = bbox::BoundingBox::<f64>::new(&na::Point3::new(0., 0., 0.),
-//!                                          &na::Point3::new(1., 2., 3.));
-//! let result = bbox.contains(&na::Point3::new(1., 1., 1.));
+//! let bbox = bbox::BoundingBox::<f64>::new(&na::Point::from([0., 0., 0.]),
+//!                                          &na::Point::from([1., 2., 3.]));
+//! let result = bbox.contains(&na::Point::from([1., 1., 1.]));
 //! ```
 //! Calculate approximate distance of a point to the Box:
 //!
 //! ```rust
 //! use nalgebra as na;
-//! let bbox = bbox::BoundingBox::<f64>::new(&na::Point3::new(0., 0., 0.),
-//!                                          &na::Point3::new(1., 2., 3.));
-//! let distance = bbox.distance(&na::Point3::new(1., 1., 1.));
+//! let bbox = bbox::BoundingBox::<f64>::new(&na::Point::from([0., 0., 0.]),
+//!                                          &na::Point::from([1., 2., 3.]));
+//! let distance = bbox.distance(&na::Point::from([1., 1., 1.]));
 //! ```
 //! ## Cargo Features
 //!
@@ -283,53 +283,57 @@ mod test {
 
     #[test]
     fn box_contains_points_inside() {
-        let bbox =
-            BoundingBox::<f64>::new(&na::Point3::new(0., 0., 0.), &na::Point3::new(1., 2., 3.));
-        assert!(bbox.contains(&na::Point3::new(0., 0., 0.)));
-        assert!(bbox.contains(&na::Point3::new(0., 1., 0.)));
-        assert!(bbox.contains(&na::Point3::new(1., 0., 1.)));
-        assert!(bbox.contains(&na::Point3::new(1., 1., 1.)));
-        assert!(!bbox.contains(&na::Point3::new(2., 2., 2.)));
-        assert!(!bbox.contains(&na::Point3::new(-1., -1., -1.)));
+        let bbox = BoundingBox::<f64>::new(
+            &na::Point::from([0., 0., 0.]),
+            &na::Point::from([1., 2., 3.]),
+        );
+        assert!(bbox.contains(&na::Point::from([0., 0., 0.])));
+        assert!(bbox.contains(&na::Point::from([0., 1., 0.])));
+        assert!(bbox.contains(&na::Point::from([1., 0., 1.])));
+        assert!(bbox.contains(&na::Point::from([1., 1., 1.])));
+        assert!(!bbox.contains(&na::Point::from([2., 2., 2.])));
+        assert!(!bbox.contains(&na::Point::from([-1., -1., -1.])));
     }
 
     #[test]
     fn box_from_points() {
         let points = [
-            na::Point3::new(0., 0., 0.),
-            na::Point3::new(1., 1., 0.),
-            na::Point3::new(0., -2., 2.),
+            na::Point::from([0., 0., 0.]),
+            na::Point::from([1., 1., 0.]),
+            na::Point::from([0., -2., 2.]),
         ];
         for bbox in [
             BoundingBox::from(points),            // from array
             BoundingBox::from(&points[..]),       // from slice
             BoundingBox::from(Vec::from(points)), // from vector
         ] {
-            assert_relative_eq!(bbox.min, na::Point3::new(0., -2., 0.));
-            assert_relative_eq!(bbox.max, na::Point3::new(1., 1., 2.));
+            assert_relative_eq!(bbox.min, na::Point::from([0., -2., 0.]));
+            assert_relative_eq!(bbox.max, na::Point::from([1., 1., 2.]));
         }
     }
 
     #[test]
     fn get_corners() {
-        let bbox =
-            BoundingBox::<f64>::new(&na::Point3::new(1., 2., 3.), &na::Point3::new(4., 5., 6.));
+        let bbox = BoundingBox::<f64>::new(
+            &na::Point::from([1., 2., 3.]),
+            &na::Point::from([4., 5., 6.]),
+        );
         let corners = bbox.get_corners();
-        assert!(corners.contains(&na::Point3::new(1., 2., 3.)));
-        assert!(corners.contains(&na::Point3::new(1., 2., 6.)));
-        assert!(corners.contains(&na::Point3::new(1., 5., 3.)));
-        assert!(corners.contains(&na::Point3::new(1., 5., 6.)));
-        assert!(corners.contains(&na::Point3::new(4., 2., 3.)));
-        assert!(corners.contains(&na::Point3::new(4., 2., 6.)));
-        assert!(corners.contains(&na::Point3::new(4., 5., 3.)));
-        assert!(corners.contains(&na::Point3::new(4., 5., 6.)));
+        assert!(corners.contains(&na::Point::from([1., 2., 3.])));
+        assert!(corners.contains(&na::Point::from([1., 2., 6.])));
+        assert!(corners.contains(&na::Point::from([1., 5., 3.])));
+        assert!(corners.contains(&na::Point::from([1., 5., 6.])));
+        assert!(corners.contains(&na::Point::from([4., 2., 3.])));
+        assert!(corners.contains(&na::Point::from([4., 2., 6.])));
+        assert!(corners.contains(&na::Point::from([4., 5., 3.])));
+        assert!(corners.contains(&na::Point::from([4., 5., 6.])));
     }
 
     #[test]
     fn is_empty() {
         let bbox = BoundingBox::<f64>::neg_infinity();
         assert!(bbox.is_empty());
-        let bbox = BoundingBox::<f64>::from([na::Point3::new(0., 0., 0.)]);
+        let bbox = BoundingBox::<f64>::from([na::Point::from([0., 0., 0.])]);
         assert!(!bbox.is_empty());
     }
 
@@ -337,85 +341,113 @@ mod test {
     fn is_finite() {
         let bbox = BoundingBox::<f64>::neg_infinity();
         assert!(!bbox.is_finite());
-        let bbox = BoundingBox::<f64>::from([na::Point3::new(0., 0., 0.)]);
+        let bbox = BoundingBox::<f64>::from([na::Point::from([0., 0., 0.])]);
         assert!(bbox.is_finite());
         let bbox = BoundingBox::<f64>::new(
-            &na::Point3::new(0., 0., 0.),
-            &na::Point3::new(f64::INFINITY, 1., 1.),
+            &na::Point::from([0., 0., 0.]),
+            &na::Point::from([f64::INFINITY, 1., 1.]),
         );
         assert!(!bbox.is_finite());
     }
 
     #[test]
     fn center() {
-        let bbox =
-            BoundingBox::<f64>::new(&na::Point3::new(0., 0., 0.), &na::Point3::new(1., 1., 1.));
-        assert_relative_eq!(bbox.center(), na::Point3::new(0.5, 0.5, 0.5));
+        let bbox = BoundingBox::<f64>::new(
+            &na::Point::from([0., 0., 0.]),
+            &na::Point::from([1., 1., 1.]),
+        );
+        assert_relative_eq!(bbox.center(), na::Point::from([0.5, 0.5, 0.5]));
     }
 
     #[test]
     fn transform_with_translation() {
-        let bbox =
-            BoundingBox::<f64>::new(&na::Point3::new(0., 0., 0.), &na::Point3::new(1., 1., 1.));
+        let bbox = BoundingBox::<f64>::new(
+            &na::Point::from([0., 0., 0.]),
+            &na::Point::from([1., 1., 1.]),
+        );
         assert_relative_eq!(
             bbox.transform(&na::Translation3::new(1., 2., 3.).to_homogeneous()),
-            BoundingBox::<f64>::new(&na::Point3::new(1., 2., 3.), &na::Point3::new(2., 3., 4.),)
+            BoundingBox::<f64>::new(
+                &na::Point::from([1., 2., 3.]),
+                &na::Point::from([2., 3., 4.]),
+            )
         );
     }
 
     #[test]
     fn transform_with_rotation() {
-        let bbox =
-            BoundingBox::<f64>::new(&na::Point3::new(0., 0., 0.), &na::Point3::new(1., 1., 1.));
+        let bbox = BoundingBox::<f64>::new(
+            &na::Point::from([0., 0., 0.]),
+            &na::Point::from([1., 1., 1.]),
+        );
         assert_relative_eq!(
             bbox.transform(
                 &na::Rotation::from_euler_angles(::std::f64::consts::PI / 2., 0., 0.)
                     .to_homogeneous()
             ),
-            BoundingBox::<f64>::new(&na::Point3::new(0., -1., 0.), &na::Point3::new(1., 0., 1.),)
+            BoundingBox::<f64>::new(
+                &na::Point::from([0., -1., 0.]),
+                &na::Point::from([1., 0., 1.]),
+            )
         );
     }
 
     #[test]
     fn union_of_two_boxes() {
-        let bbox1 =
-            BoundingBox::<f64>::new(&na::Point3::new(0., 0., 0.), &na::Point3::new(4., 8., 16.));
-        let bbox2 =
-            BoundingBox::<f64>::new(&na::Point3::new(2., 2., 2.), &na::Point3::new(16., 4., 8.));
+        let bbox1 = BoundingBox::<f64>::new(
+            &na::Point::from([0., 0., 0.]),
+            &na::Point::from([4., 8., 16.]),
+        );
+        let bbox2 = BoundingBox::<f64>::new(
+            &na::Point::from([2., 2., 2.]),
+            &na::Point::from([16., 4., 8.]),
+        );
         assert_relative_eq!(
             bbox1.union(&bbox2),
-            BoundingBox::<f64>::new(&na::Point3::new(0., 0., 0.), &na::Point3::new(16., 8., 16.),)
+            BoundingBox::<f64>::new(
+                &na::Point::from([0., 0., 0.]),
+                &na::Point::from([16., 8., 16.]),
+            )
         );
     }
 
     #[test]
     fn intersection_of_two_boxes() {
-        let bbox1 =
-            BoundingBox::<f64>::new(&na::Point3::new(0., 0., 0.), &na::Point3::new(4., 8., 16.));
-        let bbox2 =
-            BoundingBox::<f64>::new(&na::Point3::new(2., 2., 2.), &na::Point3::new(16., 4., 8.));
+        let bbox1 = BoundingBox::<f64>::new(
+            &na::Point::from([0., 0., 0.]),
+            &na::Point::from([4., 8., 16.]),
+        );
+        let bbox2 = BoundingBox::<f64>::new(
+            &na::Point::from([2., 2., 2.]),
+            &na::Point::from([16., 4., 8.]),
+        );
         assert_relative_eq!(
             bbox1.intersection(&bbox2),
-            BoundingBox::<f64>::new(&na::Point3::new(2., 2., 2.), &na::Point3::new(4., 4., 8.),)
+            BoundingBox::<f64>::new(
+                &na::Point::from([2., 2., 2.]),
+                &na::Point::from([4., 4., 8.]),
+            )
         );
     }
 
     #[test]
     fn dilate() {
-        let mut bbox =
-            BoundingBox::<f64>::new(&na::Point3::new(0., 0., 0.), &na::Point3::new(1., 1., 1.));
+        let mut bbox = BoundingBox::<f64>::new(
+            &na::Point::from([0., 0., 0.]),
+            &na::Point::from([1., 1., 1.]),
+        );
         assert_relative_eq!(
             bbox.dilate(0.1),
             &mut BoundingBox::<f64>::new(
-                &na::Point3::new(-0.1, -0.1, -0.1),
-                &na::Point3::new(1.1, 1.1, 1.1),
+                &na::Point::from([-0.1, -0.1, -0.1]),
+                &na::Point::from([1.1, 1.1, 1.1]),
             )
         );
         assert_relative_eq!(
             bbox.dilate(-0.5),
             &mut BoundingBox::<f64>::new(
-                &na::Point3::new(0.4, 0.4, 0.4),
-                &na::Point3::new(0.6, 0.6, 0.6),
+                &na::Point::from([0.4, 0.4, 0.4]),
+                &na::Point::from([0.6, 0.6, 0.6]),
             )
         );
     }
@@ -423,8 +455,8 @@ mod test {
     #[test]
     fn box_contains_inserted_points() {
         let mut bbox = BoundingBox::neg_infinity();
-        let p1 = na::Point3::new(1., 0., 0.);
-        let p2 = na::Point3::new(0., 2., 3.);
+        let p1 = na::Point::from([1., 0., 0.]);
+        let p2 = na::Point::from([0., 2., 3.]);
         assert!(!bbox.contains(&p1));
         bbox.insert(&p1);
         assert!(bbox.contains(&p1));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,24 +74,22 @@ pub struct BoundingBox<S: 'static + Debug + Copy + PartialEq> {
     pub max: na::Point<S, 3>,
 }
 
-fn point_min<S: 'static + Float + Debug>(p: &[na::Point<S, 3>]) -> na::Point<S, 3> {
-    p.iter().fold(
-        na::Point::from([S::infinity(), S::infinity(), S::infinity()]),
-        |mut min, current| {
-            min.x = min.x.min(current.x);
-            min.y = min.y.min(current.y);
-            min.z = min.z.min(current.z);
+fn point_min<S: 'static + Float + Debug, const D: usize>(p: &[na::Point<S, D>]) -> na::Point<S, D> {
+    p.iter()
+        .fold(na::Point::from([S::infinity(); D]), |mut min, current| {
+            for (min_i, current_i) in min.iter_mut().zip(current.iter()) {
+                *min_i = min_i.min(*current_i);
+            }
             min
-        },
-    )
+        })
 }
-fn point_max<S: 'static + Float + Debug>(p: &[na::Point<S, 3>]) -> na::Point<S, 3> {
+fn point_max<S: 'static + Float + Debug, const D: usize>(p: &[na::Point<S, D>]) -> na::Point<S, D> {
     p.iter().fold(
-        na::Point::from([S::neg_infinity(), S::neg_infinity(), S::neg_infinity()]),
+        na::Point::from([S::neg_infinity(); D]),
         |mut max, current| {
-            max.x = max.x.max(current.x);
-            max.y = max.y.max(current.y);
-            max.z = max.z.max(current.z);
+            for (max_i, current_i) in max.iter_mut().zip(current.iter()) {
+                *max_i = max_i.max(*current_i);
+            }
             max
         },
     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,8 +189,8 @@ impl<S: Float + Debug + na::RealField + simba::scalar::RealField, const D: usize
     /// Get the corners of the Bounding Box
     ///
     /// Warning: bounding box of dimension D has 2^D corners
-    pub fn get_corners(&self) -> Vec<na::Point<S, 3>> {
-        (0..2usize.pow(3))
+    pub fn get_corners(&self) -> Vec<na::Point<S, D>> {
+        (0..2usize.pow(D as u32))
             .map(|i| {
                 na::Point::from(std::array::from_fn(|d| match (i >> d) & 1 {
                     0 => self.min[d],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,16 +65,7 @@ use nalgebra as na;
 use num_traits::Float;
 use std::fmt::Debug;
 
-/// 3D Bounding Box - defined by two diagonally opposing points.
-#[derive(Clone, Debug, PartialEq)]
-pub struct BoundingBox<S: 'static + Debug + Copy + PartialEq> {
-    /// X-Y-Z-Minimum corner of the box.
-    pub min: na::Point<S, 3>,
-    /// X-Y-Z-Maximum corner of the box.
-    pub max: na::Point<S, 3>,
-}
-
-fn point_best<S: 'static + Float + Debug, const D: usize>(
+fn points_best<S: 'static + Float + Debug, const D: usize>(
     p: &[na::Point<S, D>],
     op: fn(S, S) -> S,
 ) -> na::Point<S, D> {
@@ -89,18 +80,32 @@ fn point_best<S: 'static + Float + Debug, const D: usize>(
     )
 }
 
-fn point_min<S: 'static + Float + Debug, const D: usize>(p: &[na::Point<S, D>]) -> na::Point<S, D> {
-    point_best(p, S::min)
+fn points_min<S: 'static + Float + Debug, const D: usize>(
+    p: &[na::Point<S, D>],
+) -> na::Point<S, D> {
+    points_best(p, S::min)
 }
-fn point_max<S: 'static + Float + Debug, const D: usize>(p: &[na::Point<S, D>]) -> na::Point<S, D> {
-    point_best(p, S::max)
+
+fn points_max<S: 'static + Float + Debug, const D: usize>(
+    p: &[na::Point<S, D>],
+) -> na::Point<S, D> {
+    points_best(p, S::max)
+}
+
+/// 3D Bounding Box - defined by two diagonally opposing points.
+#[derive(Clone, Debug, PartialEq)]
+pub struct BoundingBox<S: 'static + Debug + Copy + PartialEq> {
+    /// X-Y-Z-Minimum corner of the box.
+    pub min: na::Point<S, 3>,
+    /// X-Y-Z-Maximum corner of the box.
+    pub max: na::Point<S, 3>,
 }
 
 impl<S: Float + na::RealField, T: AsRef<[na::Point<S, 3>]>> From<T> for BoundingBox<S> {
     fn from(points: T) -> Self {
         Self {
-            min: point_min(points.as_ref()),
-            max: point_max(points.as_ref()),
+            min: points_min(points.as_ref()),
+            max: points_max(points.as_ref()),
         }
     }
 }
@@ -159,15 +164,15 @@ impl<S: Float + Debug + na::RealField + simba::scalar::RealField> BoundingBox<S>
     /// Create a CSG Union of two Bounding Boxes.
     pub fn union(&self, other: &Self) -> Self {
         Self {
-            min: point_min(&[self.min, other.min]),
-            max: point_max(&[self.max, other.max]),
+            min: points_min(&[self.min, other.min]),
+            max: points_max(&[self.max, other.max]),
         }
     }
     /// Create a CSG Intersection of two Bounding Boxes.
     pub fn intersection(&self, other: &Self) -> Self {
         Self {
-            min: point_max(&[self.min, other.min]),
-            max: point_min(&[self.max, other.max]),
+            min: points_max(&[self.min, other.min]),
+            max: points_min(&[self.max, other.max]),
         }
     }
     /// Get the corners of the Bounding Box


### PR DESCRIPTION
I have generalized bbox to the generic dimension. Please check if the implementation is correct, especially for the distance function. I think in the future it would be useful to modify the distance function to calculate the exact distance, the current implementation is confusing. I was not able to generalize the transform function, so it is only defined in 3d for now.