### PR TITLE
Update CI workflows and modernize Rust edition to 2024

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,13 +18,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Install stable Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-            toolchain: stable
-            override: true
-            components: rustfmt, clippy
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
 
       - name: build
         run: cargo build --release --all-features

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,11 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-            toolchain: stable
-            override: true
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
       - uses: katyo/publish-crates@v2
         with:
-            registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,19 +13,20 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  check--and-test:
+  check-and-test:
 
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - name: Install stable Toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
-            toolchain: stable
-            override: true
-            components: rustfmt, clippy
+          components: rustfmt, clippy
 
+      - name: fmt
+        run: cargo fmt --check
+      - name: clippy
+        run: cargo clippy --all-features -- -D warnings
       - name: check
         run: cargo check
       - name: test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bbox"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["Henning Meyer <tutmann@gmail.com>"]
 edition = "2024"
 rust-version = "1.85"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,8 @@
 name = "bbox"
 version = "0.14.1"
 authors = ["Henning Meyer <tutmann@gmail.com>"]
-edition = "2021"
+edition = "2024"
+rust-version = "1.85"
 
 description = "Managing axis aligned Bounding Boxes."
 repository = "https://github.com/hmeyer/bbox"
@@ -18,7 +19,6 @@ path = "src/lib.rs"
 mint = ["nalgebra/mint"]
 
 [dependencies]
-approx = "0.5.0"
-nalgebra = "0.31.2"
-num-traits = "0.2.14"
-simba = "0.7.2"
+approx = "0.5"
+nalgebra = "0.34"
+num-traits = "0.2"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,1 @@
-format_strings = false
 reorder_imports = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,9 +133,7 @@ impl<S: Float + na::RealField, T: AsRef<[na::Point<S, D>]>, const D: usize> From
     }
 }
 
-impl<S: Float + Debug + na::RealField + simba::scalar::RealField, const D: usize>
-    BoundingBox<S, D>
-{
+impl<S: Float + Debug + na::RealField, const D: usize> BoundingBox<S, D> {
     /// Returns an infinte sized box.
     pub fn infinity() -> Self {
         Self {
@@ -244,7 +242,7 @@ impl<S: Float + Debug + na::RealField + simba::scalar::RealField, const D: usize
     }
 }
 
-impl<S: Float + Debug + na::RealField + simba::scalar::RealField> BoundingBox<S, 3> {
+impl<S: Float + Debug + na::RealField> BoundingBox<S, 3> {
     /// Transform a Bounding Box - resulting in a enclosing axis aligned Bounding Box.
     pub fn transform(&self, mat: &na::Matrix4<S>) -> Self {
         let corners = self.get_corners();
@@ -399,7 +397,7 @@ mod test {
         );
         assert_relative_eq!(
             bbox.transform(
-                &na::Rotation::from_euler_angles(::std::f64::consts::PI / 2., 0., 0.)
+                &na::Rotation::from_euler_angles(std::f64::consts::PI / 2., 0., 0.)
                     .to_homogeneous()
             ),
             BoundingBox::new(


### PR DESCRIPTION
## Summary
This PR modernizes the project's Rust tooling and dependencies. It updates the edition to 2024, bumps the MSRV to 1.85, upgrades CI workflows to use current action versions, and removes unnecessary trait bounds.

## Key Changes

- **Edition & MSRV**: Updated `Cargo.toml` edition from 2021 to 2024 and set `rust-version = "1.85"`
- **CI Workflows**: Modernized all GitHub Actions workflows:
  - Upgraded `actions/checkout` from v2/v3 to v4
  - Replaced deprecated `actions-rs/toolchain@v1` with `dtolnay/rust-toolchain@stable`
  - Added explicit `fmt` and `clippy` check steps in test workflow
  - Fixed YAML indentation inconsistencies
- **Dependencies**: Updated to more flexible version constraints:
  - `nalgebra`: 0.31.2 → 0.34
  - `approx`: 0.5.0 → 0.5
  - `num-traits`: 0.2.14 → 0.2
  - Removed unused `simba` dependency from `Cargo.toml`
- **Code Cleanup**:
  - Removed `simba::scalar::RealField` trait bound from `BoundingBox` implementations (no longer needed)
  - Simplified path syntax: `::std::f64::consts::PI` → `std::f64::consts::PI`
  - Removed `format_strings = false` from `rustfmt.toml` (uses default behavior)

## Implementation Details

The removal of `simba::scalar::RealField` trait bounds is safe because `nalgebra 0.34` no longer requires it for the operations being performed. The trait bound was redundant given the existing `na::RealField` constraint.

https://claude.ai/code/session_019hdze2A1A1ugGrNQz7A7M6