### PR TITLE
Rename master branch to main in CI workflows and README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"  # run daily at midnight

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"  # run daily at midnight

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bbox
-![test workflow](https://github.com/hmeyer/bbox/actions/workflows/test.yml/badge.svg?branch=master)
-![build workflow](https://github.com/hmeyer/bbox/actions/workflows/build.yml/badge.svg?branch=master)
+![test workflow](https://github.com/hmeyer/bbox/actions/workflows/test.yml/badge.svg?branch=main)
+![build workflow](https://github.com/hmeyer/bbox/actions/workflows/build.yml/badge.svg?branch=main)
 [![Cargo](https://img.shields.io/crates/v/bbox.svg)](https://crates.io/crates/bbox)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Downloads](https://img.shields.io/crates/d/bbox.svg)](#downloads)


### PR DESCRIPTION
Update branch references from master to main in GitHub Actions workflows (test.yml, build.yml) and README badge URLs.

https://claude.ai/code/session_01HbGuLoWzkrWhuJViHghMYt